### PR TITLE
Add PREFIX=, revert DESTDIR= to previous usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ usage:
 	@echo "make imapsync_elf_x86.bin"
 	@echo "make publish"
 
-DESTDIR ?= /usr
+PREFIX ?= /usr
 DIST_NAME=imapsync-$(VERSION)
 DIST_FILE=$(DIST_NAME).tgz
 DEB_FILE=$(DIST_NAME).deb
@@ -74,12 +74,12 @@ imapsync.1: imapsync
 	pod2man imapsync > imapsync.1
 
 install: testp imapsync.1
-	mkdir -p $(DESTDIR)/bin
-	install imapsync $(DESTDIR)/bin/imapsync
-	chmod 755 $(DESTDIR)/bin/imapsync
-	mkdir -p $(DESTDIR)/share/man/man1
-	install imapsync.1 $(DESTDIR)/share/man/man1/imapsync.1
-	chmod 644 $(DESTDIR)/share/man/man1/imapsync.1
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	install imapsync $(DESTDIR)$(PREFIX)/bin/imapsync
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/imapsync
+	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+	install imapsync.1 $(DESTDIR)$(PREFIX)/share/man/man1/imapsync.1
+	chmod 644 $(DESTDIR)$(PREFIX)/share/man/man1/imapsync.1
 
 .PHONY: cidone ci
 


### PR DESCRIPTION
This is more in line with normal convention for make install.  This allows DonGar to use make install PREFIX=/usr/local and doesn't break distros like Fedora from using make install DESTDIR=$RPM_BUILD_ROOT
