### PR TITLE
XOAUTH2 Support

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -2338,7 +2338,7 @@ sub xoauth2 {
         my $imap = shift;
 
         # Get iss (service account address), keyfile name, and keypassword if necessary
-        my ($iss,$keyfile,$keypass) = $imap->Password =~ /([\-\d\w\@\.]+);([a-zA-Z0-9\_\-\.]+);?(.*)?/;
+        my ($iss,$keyfile,$keypass) = $imap->Password =~ /([\-\d\w\@\.]+);([a-zA-Z0-9\_\-\.\/]+);?(.*)?/;
 
         # Assume key password is google default if not provided
         $keypass = 'notasecret' if not $keypass;

--- a/imapsync
+++ b/imapsync
@@ -2186,6 +2186,7 @@ sub authenticate_imap {
         }
         
 	$imap->Authcallback(\&xoauth) if ( 'XOAUTH' eq $authmech ) ;
+	$imap->Authcallback(\&xoauth2) if ( 'XOAUTH2' eq $authmech ) ;
 	$imap->Authcallback(\&plainauth) if ( ( 'PLAIN' eq $authmech ) or ( 'EXTERNAL' eq $authmech )  ) ;
 	
         $imap->Domain($domain) if (defined($domain)) ;
@@ -2311,6 +2312,74 @@ sub plainauth {
         my $string = sprintf("%s\x00%s\x00%s", $imap->User,
                             $imap->Authuser, $imap->Password);
         return encode_base64("$string", "");
+}
+
+# Used this as an example: https://gist.github.com/gsainio/6322375
+#
+# And this as a reference: https://developers.google.com/accounts/docs/OAuth2ServiceAccount
+# (note there is an http/rest tab, where the real info is hidden away... went on a witch hunt
+# until I noticed that...)
+#
+# This is targeted at gmail to maintain compatibility after google's oauth1 service is deactivated
+# on May 5th, 2015: https://developers.google.com/gmail/oauth_protocol
+# If there are other oauth2 implementations out there, this would need to be modified to be
+# compatible
+#
+# This is a good guide on setting up the google api/apps side of the equation:
+# http://www.limilabs.com/blog/oauth2-gmail-imap-service-account
+sub xoauth2 {
+        use JSON::WebToken;
+        use LWP::UserAgent;
+        use HTML::Entities;
+        use JSON;
+        use MIME::Base64 qw(encode_base64);
+
+        my $code = shift;
+        my $imap = shift;
+
+        # Get iss (service account address), keyfile name, and keypassword if necessary
+        my ($iss,$keyfile,$keypass) = $imap->Password =~ /([\-\d\w\@\.]+);([a-zA-Z0-9\_\-\.]+);?(.*)?/;
+
+        # Assume key password is google default if not provided
+        $keypass = 'notasecret' if not $keypass;
+
+        $debug and print("Service account: $iss\nKey file: $keyfile\nKey password: $keypass\n");
+
+        # Get private key from p12 file (would be better in perl...)
+        my $key = `openssl pkcs12 -in $keyfile -nodes -nocerts -passin pass:$keypass -nomacver`;
+
+        $debug and print("Private key:\n$key\n");
+
+        # Create jwt of oauth2 request
+        my $time = time();
+        my $jwt = JSON::WebToken->encode( {
+                                            'iss'   => $iss, # service account
+                                            'scope' => 'https://mail.google.com/',
+                                            'aud'   => 'https://www.googleapis.com/oauth2/v3/token',
+                                            'exp'   => $time + 3600,
+                                            'iat'   => $time,
+                                            'prn'   => $imap->User # user to auth as
+                                          },
+                                          $key, 'RS256', {'typ' => 'JWT'} );
+
+        # Post oauth2 request
+        my $ua = LWP::UserAgent->new();
+        my $response = $ua->post('https://www.googleapis.com/oauth2/v3/token',
+                                 { grant_type => encode_entities('urn:ietf:params:oauth:grant-type:jwt-bearer'),
+                                   assertion => $jwt } );
+
+        unless($response->is_success()) {
+            die($response->code, "\n", $response->content, "\n");
+        }
+
+        # access_token in response is what we need
+        my $data = decode_json($response->content);
+
+        # format as oauth2 auth data
+        my $xoauth2_string = encode_base64("user=" . $imap->User . "\1auth=Bearer " . $data->{access_token} . "\1\1", "");
+
+        $debug and print("XOAUTH2 String: $xoauth2_string\n");
+        return($xoauth2_string);
 }
 
 # xoauth() thanks to Eduardo Bortoluzzi Junior


### PR DESCRIPTION
Here is a pull request that would add XOAUTH2 support. Google's OAUTH1 support is coming to an end soon (see: https://developers.google.com/accounts/docs/OAuth#shutdown-timetable), so XOAUTH2 will now be the only way to move accounts to/from Gmail in bulk.

OAUTH2 (with Google) requires creating a service account and using an encrypted keyfile. This oauth2 support  uses special input to the --passwordX argument to communicate those variables. This could be used as-is, or used as the basis for support with a different interface (custom --arguments for the keyfile, etc., when using XOAUTH2--looking at the code, the way I did it seemed much simpler, but perhaps it's too obtuse from a user's perspective?).

This introduces a requirement for JSON::WebToken.

Here are the instructions from the commit:

Makes --authmechX accept "XOAUTH2", which then uses the password for parameters.

--passwordX needs to be in the following format:
"<service account>;<keyfile location>;<keyfile password>"

<service account> is the name of the Google Developer API service account.

<keyfile location> is the location of the keyfile associated with it.

<keyfile password> is the password to access the keyfile. Entering this
password is optional--it will assume "notasecret" if not provided, which
is the default password Google uses with the keyfiles.

Example arguments for using XOAUTH might look like this:

--authmech1 xoauth2 --password1 '123456789012-abcd0abcde0ab1abc2345ab6abcdefgh@developer.gserviceaccount.com;some_keyfile.p12'

This assumes "some_keyfile" is in the current directory, and uses the default
"notasecret" password.