### PR TITLE
Add libauthen-ntlm-perl as a dependency in INSTALL notes.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -120,13 +120,14 @@ On Debian/Ubuntu:
   aptitude install libfile-copy-recursive-perl # File::Copy::Recursive
   aptitude install libio-tee-perl              # IO::Tee
   aptitude install libunicode-string-perl      # Unicode::String
+  aptitude install libauthen-ntlm-perl         # authentication module for NTLM
 
 On Ubuntu 14 (thanks to http://www.jverdeyen.be/ubuntu/imapsync-on-ubuntu/):
 
   sudo apt-get install makepasswd rcs perl-doc libio-tee-perl git
   sudo apt-get install libmail-imapclient-perl libdigest-md5-file-perl 
   sudo apt-get install libterm-readkey-perl libfile-copy-recursive-perl 
-  sudo apt-get install libunicode-string-perl
+  sudo apt-get install libunicode-string-perl libauthen-ntlm-perl
 
 On Mandriva:
 


### PR DESCRIPTION
Dependency for Debian / Ubuntu installation.