### PR TITLE
[BUGFIX] Avoid "SSL_verify_mode must be a number and not a string" error

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -2324,7 +2324,7 @@ sub set_ssl {
         #print "[$SSL_version]\n" ;
 
 	my $sslargs = [
-		SSL_verify_mode => 'SSL_VERIFY_PEER',
+		SSL_verify_mode => IO::Socket::SSL->import(qw(SSL_VERIFY_PEER)),
         	SSL_verifycn_scheme => 'imap',
                 SSL_version => $SSL_version,
         ] ;
@@ -2335,7 +2335,7 @@ sub set_ssl {
 sub set_tls {
 	my ( $imap ) = @_ ;
 	my $tlsargs = [
-		SSL_verify_mode => 'SSL_VERIFY_NONE',
+		SSL_verify_mode => IO::Socket::SSL->import(qw(SSL_VERIFY_NONE)),
         ] ;
         $imap->Starttls( $tlsargs ) ;
 	return(  ) ;


### PR DESCRIPTION
Using propertly imported constants avoids errors in the IO::Socket::SSL
package like "SSL_verify_mode must be a number and not a string at
~/lib/perl5/vendor_perl/5.16.3/IO/Socket/SSL.pm line 2154."