### PR TITLE
replace constant names with constants

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -2324,7 +2324,7 @@ sub set_ssl {
         #print "[$SSL_version]\n" ;
 
 	my $sslargs = [
-		SSL_verify_mode => 'SSL_VERIFY_PEER',
+		SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_PEER(),
         	SSL_verifycn_scheme => 'imap',
                 SSL_version => $SSL_version,
         ] ;
@@ -2335,7 +2335,7 @@ sub set_ssl {
 sub set_tls {
 	my ( $imap ) = @_ ;
 	my $tlsargs = [
-		SSL_verify_mode => 'SSL_VERIFY_NONE',
+		SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
         ] ;
         $imap->Starttls( $tlsargs ) ;
 	return(  ) ;


### PR DESCRIPTION
As of IO::Socket::SSL 2.017, it is illegal to pass a non-number to
IO::Socket::SSL as the SSL_verify_mode.  Previously, any string
was treated as NONE.  This change was not announced.