### PR TITLE
ipv6 and gmail

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -485,6 +485,7 @@ use IO::Socket qw(:crlf SOL_SOCKET SO_KEEPALIVE) ;
 #use IO::Socket::SSL ;
 use IO::Tee ;
 use IPC::Open3 'open3' ;
+use IO::Socket::SSL 'inet4';
 use Mail::IMAPClient 3.29 ;
 use MIME::Base64 ;
 use POSIX qw(uname SIGALRM) ;


### PR DESCRIPTION
Something is not working in the current implementation with gmail. I think it might be related to ipv6, as forcing imapsync to use ipv4 seems to work.

The problem is reported over and over in newsgroups. While I'm not convinced that this is a good solution, it is at least a workaround.
