### PR TITLE
Gmail labels

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -907,6 +907,7 @@ my(
         $disarmreadreceipts,
         $mixfolders, $skipemptyfolders,
 	$fetch_hash_set,
+	$porttagstogmail,
 );
 
 # main program
@@ -5401,6 +5402,21 @@ EOF
 }
 
 
+sub port_tags_to_gmail_labels {
+	my( $id, $h1_flags ) = @_;
+
+	# Thunderbird, Zimbra, and possibly other IMAP clients, store user defined
+	# tags as IMAP keywords which are flags that don't start with '\' [1].
+	# Split apart the current flag string, remove any that start with a backslash,
+	# and then join them back into a single string.
+	#
+	# [1] https://tools.ietf.org/html/rfc3501#page-11
+	( $debug or $debugflags ) and myprint( "gmail labels: starting with $h1_flags\n" );
+	my $labels = join( ' ', grep( !/^\\/, split( /\s/, $h1_flags ) ) );
+	( $debug or $debugflags ) and myprint( "gmail labels: labels are '$labels'\n" );
+	$imap2->store( $id, "+X-GM-LABELS ($labels)" ) if $labels;
+}
+
 # GlobVar
 # $dry
 # $max_msg_size_in_bytes
@@ -5449,6 +5465,10 @@ sub append_message_on_host2 {
 			$total_bytes_transferred += $h1_size ;
 			$nb_msg_transferred += 1 ;
                         $h1_nb_msg_processed +=1 ;
+
+			if ($porttagstogmail) {
+				port_tags_to_gmail_labels($new_id, $h1_flags);
+			}
 
                         my $time_spent = timesince( $begin_transfer_time ) ;
                         my $rate = bytes_display_string( $total_bytes_transferred / $time_spent ) ;
@@ -8982,6 +9002,8 @@ sub usage {
                        credentials, then exit.
  --justfolders       : Do only things about folders (ignore messages).
 
+ --porttagstogmail   : Convert tags (IMAP keywords) to GMail labels.
+
  --help              : print this help.
 
  Example: to synchronize imap account "test1" on "test1.lamiral.info"
@@ -9203,6 +9225,7 @@ sub get_options {
         'f1f2=s%'          => \$sync->{f1f2},
         'justfolderlists!' => \$sync->{justfolderlists},
         'delete1emptyfolders' => \$sync->{delete1emptyfolders},
+	'porttagstogmail' => \$porttagstogmail,
         ) ;
 
 

--- a/imapsync
+++ b/imapsync
@@ -907,7 +907,7 @@ my(
         $disarmreadreceipts,
         $mixfolders, $skipemptyfolders,
 	$fetch_hash_set,
-	$porttagstogmail,
+	$porttagstogmail, @excludetags,
 );
 
 # main program
@@ -5408,11 +5408,17 @@ sub port_tags_to_gmail_labels {
 	# Thunderbird, Zimbra, and possibly other IMAP clients, store user defined
 	# tags as IMAP keywords which are flags that don't start with '\' [1].
 	# Split apart the current flag string, remove any that start with a backslash,
-	# and then join them back into a single string.
+	# remove any the user *doesn't* want to port, and then join them back into
+	# a single string.
 	#
 	# [1] https://tools.ietf.org/html/rfc3501#page-11
 	( $debug or $debugflags ) and myprint( "gmail labels: starting with $h1_flags\n" );
-	my $labels = join( ' ', grep( !/^\\/, split( /\s/, $h1_flags ) ) );
+	my @label_list = grep( !/^\\/, split( /\s/, $h1_flags ) );
+	foreach my $exclude_regex ( @excludetags ) {
+		#( $debug or $debugflags ) and myprint( "gmail labels: exclude regex is '$exclude_regex'\n" );
+		@label_list = grep( !/$exclude_regex/, @label_list );
+	}
+	my $labels = join(' ', @label_list);
 	( $debug or $debugflags ) and myprint( "gmail labels: labels are '$labels'\n" );
 	$imap2->store( $id, "+X-GM-LABELS ($labels)" ) if $labels;
 }
@@ -9003,6 +9009,8 @@ sub usage {
  --justfolders       : Do only things about folders (ignore messages).
 
  --porttagstogmail   : Convert tags (IMAP keywords) to GMail labels.
+ --excludetags   reg : Skip (don't port to GMail) tags that match this
+                       regex (similar to the --exclude argument)
 
  --help              : print this help.
 
@@ -9226,6 +9234,7 @@ sub get_options {
         'justfolderlists!' => \$sync->{justfolderlists},
         'delete1emptyfolders' => \$sync->{delete1emptyfolders},
 	'porttagstogmail' => \$porttagstogmail,
+	'excludetags=s' => \@excludetags,
         ) ;
 
 


### PR DESCRIPTION
Per discussion in #6, here is an implementation of converting IMAP keywords to GMail labels.  I've tested it on about a year's worth of my corporate email (~3k messages), moving from Zimbra to GMail (really GSuite) which contained about 20 unique tags.  That process made me add an `--excludetags` option to skip porting some of Zimbra's internal IMAP keywords (second commit on this branch).  I also tested that Zimbra (the IMAP server I have easy access to) doesn't barf too badly if I attempt to use the `X-GM-LABELS` command (it simply rejects it as an invalid store command but allows the client to continue issuing other commands).

I have attempted to match the coding style of the existing code, but let me know if I missed anything really important...

Possibly useful reference material:
 * [IMAP keyword spec](https://tools.ietf.org/html/rfc3501#page-11)
 * [Thunderbird description of tags](http://kb.mozillazine.org/Tags#IMAP)
 * [GMail X-GM-LABELS extension](https://developers.google.com/gmail/imap_extensions#access_to_gmail_labels_x-gm-labels)
