### PR TITLE
Don't skip messages with missing INTERNALDATE

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -5129,7 +5129,7 @@ sub message_for_host2 {
 	my ( $sync, $h1_msg, $h1_fold, $h1_size, $h1_flags, $h1_idate, $h1_fir_ref, $string_ref ) = @_ ;
 
         # abort when missing a parameter
-        if ( (!$sync) or  (!$h1_msg) or (!$h1_fold) or (!$h1_size) or (!defined $h1_flags) or (!$h1_idate) or (!$h1_fir_ref) or (!$string_ref) ) {
+        if ( (!$sync) or  (!$h1_msg) or (!$h1_fold) or (!$h1_size) or (!defined $h1_flags) or (!defined $h1_idate) or (!$h1_fir_ref) or (!$string_ref) ) {
                 return ;
         }
 


### PR DESCRIPTION
Not all messages contain an INTERNALDATE attribute. This small change makes syncing for these messages possible.