### PR TITLE
Update INSTALL.Debian.txt

### DIFF
--- a/INSTALL.d/INSTALL.Debian.txt
+++ b/INSTALL.d/INSTALL.Debian.txt
@@ -33,6 +33,7 @@ apt install -y \
   libcrypt-openssl-rsa-perl \
   libdata-uniqid-perl \
   libfile-copy-recursive-perl \
+  libio-socket-inet6-perl \
   libio-socket-ssl-perl \
   libio-tee-perl \
   libhtml-parser-perl \


### PR DESCRIPTION
In Debian 9, just tried with a fresh server, if you omit "libio-socket-inet6-perl", you get

"""
root@jarjar:~# ./imapsync
Can't locate IO/Socket/INET6.pm in @INC (you may need to install the IO::Socket::INET6 module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at ./imapsync line 676.
BEGIN failed--compilation aborted at ./imapsync line 676.
"""

Maybe because my machine has IPv6?