### PR TITLE
Allow --maxsleep to override --gmail{1,2}

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -11180,7 +11180,7 @@ sub gmail12  {
 	$mysync->{maxbytespersecond} ||= 20_000 ; # should be 10_000 computed from by Gmail documentation
 	$mysync->{maxbytesafter} ||= 1_000_000_000 ;
 	$mysync->{automap} = ( defined $mysync->{automap} ) ? $mysync->{automap} : 1 ;
-	$mysync->{maxsleep} = $MAX_SLEEP ;
+	$mysync->{maxsleep} = ( defined $mysync->{maxsleep} ) ? $mysync->{maxsleep} : $MAX_SLEEP ;
 	
 	push @exclude, '\[Gmail\]$' ;
 	return ;
@@ -11195,7 +11195,7 @@ sub gmail1  {
 	$mysync->{maxbytesafter} ||= 2_500_000_000 ;
 	$mysync->{automap} = ( defined $mysync->{automap} ) ? $mysync->{automap} : 1 ;
 	$skipcrossduplicates = ( defined $skipcrossduplicates ) ? $skipcrossduplicates : 1 ;
-	$mysync->{maxsleep} = $MAX_SLEEP ;
+	$mysync->{maxsleep} = ( defined $mysync->{maxsleep} ) ? $mysync->{maxsleep} : $MAX_SLEEP ;
 	
 	push @useheader, 'X-Gmail-Received', 'Message-Id' ;
 	push @regextrans2, 's,\[Gmail\].,,' ;
@@ -11215,7 +11215,7 @@ sub gmail2  {
 	$skipcrossduplicates = ( defined $skipcrossduplicates ) ? $skipcrossduplicates : 1 ;
 	$expunge1            = ( defined $expunge1 )  ? $expunge1  : 1 ;
 	$mysync->{addheader} = ( defined $mysync->{addheader} ) ? $mysync->{addheader} : 1 ;
-	$mysync->{maxsleep} = $MAX_SLEEP ;
+	$mysync->{maxsleep} = ( defined $mysync->{maxsleep} ) ? $mysync->{maxsleep} : $MAX_SLEEP ;
 	
 	push @exclude, '\[Gmail\]$' ;
 	push @useheader, 'X-Gmail-Received', 'Message-Id' ;


### PR DESCRIPTION
While backing up large gmail accounts, sleeping for longer than 2 seconds can help avoid hitting bandwidth quotas.