### PR TITLE
Update INSTALL.Docker_build.txt

### DIFF
--- a/INSTALL.d/INSTALL.Docker_build.txt
+++ b/INSTALL.d/INSTALL.Docker_build.txt
@@ -37,6 +37,7 @@ RUN apt-get update \
   libunicode-string-perl \
   liburi-perl  \
   libwww-perl \
+  libio-socket-inet6-perl \
   procps \
   wget \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Resolve error:


> Can't locate IO/Socket/INET6.pm in @INC (you may need to install the IO::Socket::INET6 module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/bin/imapsync line 713.
> BEGIN failed--compilation aborted at /usr/bin/imapsync line 713.
> 