### PR TITLE
added missing dependency: libssl-dev

### DIFF
--- a/INSTALL.d/INSTALL.Ubuntu.txt
+++ b/INSTALL.d/INSTALL.Ubuntu.txt
@@ -28,6 +28,7 @@ libnet-ssleay-perl      \
 libpar-packer-perl      \
 libreadonly-perl        \
 libregexp-common-perl   \
+libssl-dev              \
 libsys-meminfo-perl     \
 libterm-readkey-perl    \
 libtest-fatal-perl      \


### PR DESCRIPTION
Otherwise make install will fail as follows:
`# make install
sh INSTALL.d/prerequisites_imapsync
$SHELL says  /bin/bash
$0 gives  INSTALL.d/prerequisites_imapsync
ps -ef gives root     18001 17982  0 09:28 pts/9    00:00:00 sh INSTALL.d/prerequisites_imapsync
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.1 LTS
Release:	18.04
Codename:	bionic
Linux mypc 4.15.0-36-generic #39-Ubuntu SMP Mon Sep 24 16:19:09 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
Ok: Found Perl 5.26.1
Ok: Found make GNU Make 4.1
Ok: Found Perl module App::cpanminus
Ok: Found Perl module Authen::NTLM
Ok: Found Perl module CGI
Ok: Found Perl module Compress::Zlib
Failure: Not found Perl module Crypt::OpenSSL::RSA 
Ok: Found Perl module Data::Dumper
Ok: Found Perl module Data::Uniqid
Ok: Found Perl module Digest::HMAC
Ok: Found Perl module Digest::HMAC_MD5
Ok: Found Perl module Digest::MD5
Ok: Found Perl module Dist::CheckConflicts
Ok: Found Perl module Encode::Byte
Ok: Found Perl module File::Copy::Recursive
Ok: Found Perl module IO::Socket::INET
Ok: Found Perl module IO::Socket::INET6
Ok: Found Perl module IO::Socket::SSL
Ok: Found Perl module IO::Tee
Ok: Found Perl module JSON
Ok: Found Perl module JSON::WebToken
Failure: Not found Perl module JSON::WebToken::Crypt::RSA 
Ok: Found Perl module HTML::Entities
Ok: Found Perl module LWP::UserAgent
Ok: Found Perl module Mail::IMAPClient
Ok: Found Perl module Module::Implementation
Ok: Found Perl module Module::Runtime
Ok: Found Perl module Module::ScanDeps
Ok: Found Perl module Net::SSLeay
Ok: Found Perl module Package::Stash
Ok: Found Perl module Package::Stash::XS
Ok: Found Perl module PAR::Packer
Ok: Found Perl module Parse::RecDescent
Ok: Found Perl module Pod::Usage
Ok: Found Perl module Readonly
Ok: Found Perl module Regexp::Common
Ok: Found Perl module Sys::MemInfo
Ok: Found Perl module Term::ReadKey
Ok: Found Perl module Test::Fatal
Ok: Found Perl module Test::Mock::Guard
Ok: Found Perl module Test::MockObject
Ok: Found Perl module Test::More
Ok: Found Perl module Test::Pod
Ok: Found Perl module Test::Requires
Ok: Found Perl module Test::NoWarnings
Ok: Found Perl module Test::Deep
Ok: Found Perl module Test::Warn
Ok: Found Perl module Try::Tiny
Ok: Found Perl module Unicode::String
Ok: Found Perl module URI::Escape

What you have to do before using imapsync:
Install Perl module Crypt::OpenSSL::RSA
Install Perl module JSON::WebToken::Crypt::RSA
Here is a cpanm command to install missing Perl modules:
cpanm Crypt::OpenSSL::RSA JSON::WebToken::Crypt::RSA
Makefile:99: recipe for target 'testp' failed
make: *** [testp] Error 1
`