### PR TITLE
Added X-MASTERAUTH authentication scheme @benjaminclot code

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -4308,11 +4308,21 @@ sub authenticate_imap {
            $ssl, $tls, $authmech, $authuser, $reconnectretry,
            $proxyauth, $uid, $split, $Side, $h, $mysync ) = @_ ;
 
-        check_capability( $imap, $authmech, $Side ) ;
+        unless ( $authmech eq 'X-MASTERAUTH' ) {
+                check_capability( $imap, $authmech, $Side ) ;
+        }
 
         if ( $proxyauth ) {
                 $imap->Authmechanism(q{}) ;
                 $imap->User($authuser) ;
+        } elsif ( $authmech eq 'X-MASTERAUTH' ) {
+                my @challenge = $imap->tag_and_run( $authmech, "+" ) ;
+                $challenge[1] =~ s/^\+ |^\s+|\s+$//g ;
+                $imap->_imap_command( { addcrlf => 1, addtag => 0, tag => $imap->Count }, md5_hex( $challenge[1] . $password ) ) or die_clean("[$authmech]: ", $imap->LastError, "\n") ;
+                $imap->State(2) ;
+                $imap->tag_and_run( 'X-SETUSER ' . $user ) or die_clean("[X-SETUSER]: ", $imap->LastError, "\n") ;
+                $imap->State(3) ;
+                $imap->User($user) ;
         } else {
                 $imap->Authmechanism( $authmech ) unless ( $authmech eq 'LOGIN'  or $authmech eq 'PREAUTH' ) ;
                 $imap->User($user) ;
@@ -4326,7 +4336,7 @@ sub authenticate_imap {
         $imap->Authuser($authuser) ;
         $imap->Password($password) ;
 
-        unless ( $authmech eq 'PREAUTH' or $imap->login( ) ) {
+        unless ( $authmech eq 'PREAUTH' or $authmech eq 'X-MASTERAUTH' or $imap->login( ) ) {
                 my $info  = "$Side failure: Error login on [$host] with user [$user] auth" ;
                 my $einfo = $imap->LastError || @{$imap->History}[$LAST] ;
                 chomp $einfo ;


### PR DESCRIPTION
Please close this if it's not useful. I saw that there was a conflict, so I applied @benjaminclot's patch to the current master. I just synced. It seemed to work fine.

```
++++ Statistics
Transfer started on               : Mon Feb 11 14:23:29 2019
Transfer ended on                 : Mon Feb 11 14:23:40 2019
Transfer time                     : 10.6 sec
Folders synced                    : 10/10 synced
Messages transferred              : 20
Messages skipped                  : 1820
Messages found duplicate on host1 : 0
Messages found duplicate on host2 : 0
Messages void (noheader) on host1 : 0
Messages void (noheader) on host2 : 2
Messages deleted on host1         : 0
Messages deleted on host2         : 0
Total bytes transferred           : 31415034 (29.960 MiB)
Total bytes duplicate host1       : 0 (0.000 KiB)
Total bytes duplicate host2       : 0 (0.000 KiB)
Total bytes skipped               : 1250620459 (1.165 GiB)
Total bytes error                 : 0 (0.000 KiB)
Message rate                      : 1.9 messages/s
Average bandwidth rate            : 2901.7 KiB/s
Reconnections to host1            : 0
Reconnections to host2            : 0
Memory consumption at the end     : 288.9 MiB (started with 215.9 MiB)
Biggest message                   : 14952205 bytes (14.260 MiB)
Memory/biggest message ratio      : 20.3
Detected 1 errors

Check if a new imapsync release is available by adding --releasecheck
Homepage: https://imapsync.lamiral.info/
++++ Listing 1 errors encountered during the sync ( avoid this listing with --noerrorsdump ).

Err 1/1: Host1 folder Public Folders: Could not select: 53 NO SELECT Cannot access folder 'Public Folders'
Exiting with return value 111
```