### PR TITLE
libfile-tail-perl

### DIFF
--- a/INSTALL.d/INSTALL.Debian.txt
+++ b/INSTALL.d/INSTALL.Debian.txt
@@ -42,6 +42,7 @@ apt install -y            \
   libcrypt-openssl-rsa-perl   \
   libdata-uniqid-perl         \
   libfile-copy-recursive-perl \
+  libfile-tail-perl        \
   libio-socket-inet6-perl  \
   libio-socket-ssl-perl    \
   libio-tee-perl           \


### PR DESCRIPTION
On my freshly installed Debian 9 (Linux 4.9.0-3-amd64 #1 SMP Debian 4.9.30-2+deb9u5 (2017-09-19) x86_64 GNU/Linux), when I followed the instruction (without the libfile-tail-perl), I got the below error message when I ran imapsync (git cloned from the commit id f9a77ee223d895906399c8b783bc65bd63df5eb7 which was commited on Tue Jul 2 18:34:23 2019 -0500) for the first time.  But, after I had installed libfile-tail-perl package, I could successfully run imapsync.

"""
Can't locate File/Tail.pm in @INC (you may need to install the File::Tail module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at ./imapsync line 840.
BEGIN failed--compilation aborted at ./imapsync line 840.
"""