### PR TITLE
Fixed empty subject

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -10116,7 +10116,7 @@ sub subject
 
         my $header = extract_header( $string ) ;
 
-        if( $header =~ m/^Subject:\s*([^\n\r]*)\r?$/msx ) {
+        if( $header =~ m/^Subject:[ \t]*([^\n\r]*)\r?$/msx ) {
                 #myprint( "MMM[$1]\n"  ) ;
                 $subject = $1 ;
         }


### PR DESCRIPTION
Empty subject caused to pull "To: " on the other line as \s grabbed the newline.