### PR TITLE
Improve gmail

### DIFF
--- a/FAQ.d/FAQ.Gmail.txt
+++ b/FAQ.d/FAQ.Gmail.txt
@@ -170,8 +170,7 @@ imapsync \
            --maxsleep 2 \
            --synclabels \
            --resynclabels \
-           --exclude "\[Gmail\]$" \
-           --folderlast  "[Gmail]/All Mail"
+           --folder  "[Gmail]/All Mail"
 
 With --gmail1 --gmail2 you can override the parameters
 that are activated by them, for example:
@@ -215,8 +214,12 @@ incomprehensible alphabets, a headache for imap sysadmins.
 See a listing here:
 http://stackoverflow.com/questions/2185391/localized-gmail-imap-folders/2185548#2185548
 
---exclude "\[Gmail\]$"   is just there to avoid a warning error
-when selecting this not used folder.
+--synclabels and --resynclabels  causes messages to all have the
+same labels on host2 as they have on host1
+
+--folder  "[Gmail]/All Mail" makes imapsync process only the All Mail
+folder.  Since it is syncing all labels this will sync all messages with
+their correct labels.
 
 Be aware that --gmail1 --gmail2 is a special case, it's not what
 --gmail1 does plus what --gmail2 does when they are not invoked 
@@ -252,7 +255,9 @@ imapsync --host1 mail.oldhost.com     \
          --expunge1   \
          --addheader  \
          --maxsleep 2 \
+         --maxsize 35_651_584 \
          --exclude "\[Gmail\]$"  \
+         --useheader='Message-Id'
          --regextrans2 's,\[Gmail\].,,' \
          --regextrans2 's,^ +| +$,,g'
          --regextrans2 's,/ +| +/,/,g'
@@ -287,8 +292,8 @@ be 500_000_000, not 1_000_000_000, but 1GB is usually ok.
 --maxsleep 2 is to avoid sleeping more than 2 seconds when 
 the --maxbytespersecond value implies a long sleep between 2 copies.
 
---maxsize 25_000_000 is mandatory since Gmail limits messages size
-up to 25 MB. This value increases over time, it was 10 MB some 
+--maxsize 35_651_584 is mandatory since Gmail limits messages size
+up to 35 MB. This value increases over time, it was 10 MB some 
 years ago so you can try higher values. The Gmail page about
 this limit is https://support.google.com/mail/answer/6584
 
@@ -301,7 +306,6 @@ marked \Deleted but deletes or moves them just after.
 Option --expunge1 really removes messages marked \Deleted on host1 
 so they are not synced at all.
 
-
 The --addheader option is there because "Sent" folder messages 
 sometimes lack the "Message-Id:" and "Received:" headers needed 
 by imapsync to identify messages (only when --useuid is not used). 
@@ -312,6 +316,9 @@ the imap UID of the message on the host1 folder, like
 --exclude "\[Gmail\]$" is there to avoid a small examine/select error:
 "Could not examine: 43 NO [NONEXISTENT] Unknown Mailbox: [Gmail] 
 (now in authenticated state) (Failure)".
+
+--useheader='Message-Id' causes imapsync to use the Message-Id header
+to uniquely identify a message for dtecting duplicates.
 
 --regextrans2 "s/[ ]+/_/g" is there to convert blank characters not 
 accepted by gmail to character _ underscore. In fact only leading
@@ -331,6 +338,9 @@ not accepted by gmail, character ^ to character _ underscore.
 
 --regextrans2 "s/['\"\\\\]/_/g" is optional. It converts 
 characters ' or " or \ to character _ underscore.
+
+--folderlast  "[Gmail]/All Mail" makes imapsync leave the All Aail
+folder until the last.
 
 You can select folders exported to imap within the gmail preferences.
 Select or unselect some "System labels", depending on your needs.
@@ -363,7 +373,7 @@ imapsync \
            --maxbytesafter 2_500_000_000
            --automap \
            --maxsleep 2 \
-           --skipcrossduplicates \
+           --noskipcrossduplicates --skipallmailduplicates \
            --useheader="X-Gmail-Received" \
            --useheader "Message-Id" \
            --regextrans2 "s,\[Gmail\].,," \
@@ -420,6 +430,11 @@ label CanWait and only it.
 --folderlast "[Gmail]/All Mail", in conjunction with option 
 --skipcrossduplicates, will only put in "[Gmail]/All Mail"
 the messages that are not labeled at all.
+
+--skipallmailduplicates is similar to --skipcrossduplicates but it only
+skips messages in the [GMAIL]/All Mail folder.  Messages with two or
+more other labels are copied to all the corresponding IMAP folders on
+the destination.  --skipallmailduplicates is the default with --gmail1.
 
 
 https://imapsync.lamiral.info/FAQ.d/FAQ.Gmail.txt

--- a/README
+++ b/README
@@ -314,9 +314,13 @@ OPTIONS
                              X is not also Gmail.
                              Activated with --gmail1 unless --noskipcrossduplicates
 
+     --skipallmailduplicates : Used when host1 is GMail.  Skips messages in 
+                               [Gmail]/All Mail that are also in some other folder.
+
      --debugcrossduplicates : Prints which messages (UIDs) are skipped with
                               --skipcrossduplicates (and in what other folders
-                              they are).
+                              they are).  Also prints messages skipped by
+                              --skipallmailduplicates.
 
      --pipemess     cmd  : Apply this cmd command to each message content
                            before the copy.

--- a/README.md
+++ b/README.md
@@ -331,9 +331,13 @@ OPTIONS
                              X is not also Gmail.
                              Activated with --gmail1 unless --noskipcrossduplicates
 
+   --skipallmailduplicates : Used when host1 is GMail.  Skips messages in 
+                             [Gmail]/All Mail that are also in some other folder.
+
      --debugcrossduplicates : Prints which messages (UIDs) are skipped with
                               --skipcrossduplicates (and in what other folders
-                              they are).
+                              they are).  Also prints messages skipped by
+                              --skipallmailduplicates.
 
      --pipemess     cmd  : Apply this cmd command to each message content
                            before the copy.

--- a/W/imapsync.1
+++ b/W/imapsync.1
@@ -470,9 +470,13 @@ and user1 user2 are the \-\-user1 \-\-user2 values.
 \&                         X is not also Gmail.
 \&                         Activated with \-\-gmail1 unless \-\-noskipcrossduplicates
 \&
+\& \-\-skipallmailduplicates : Used when host1 is GMail.  Skips messages in 
+\&                           [Gmail]/All Mail that are also in some other folder.
+\&
 \& \-\-debugcrossduplicates : Prints which messages (UIDs) are skipped with
 \&                          \-\-skipcrossduplicates (and in what other folders
-\&                          they are).
+\&                          they are).  Also prints messages skipped by
+\&                          \-\-skipallmailduplicates.
 \&
 \& \-\-pipemess     cmd  : Apply this cmd command to each message content
 \&                       before the copy.

--- a/imapsync
+++ b/imapsync
@@ -345,10 +345,14 @@ and user1 user2 are the --user1 --user2 values.
                          in another folder,  good from Gmail to X when
                          X is not also Gmail.
                          Activated with --gmail1 unless --noskipcrossduplicates
+                         
+--skipallmailduplicates : Used when host1 is GMail.  Skips messages in 
+                          [Gmail]/All Mail that are also in some other folder.
 
  --debugcrossduplicates : Prints which messages (UIDs) are skipped with
                           --skipcrossduplicates (and in what other folders
-                          they are).
+                          they are).  Also prints messages skipped by
+                          --skipallmailduplicates.
 
  --pipemess     cmd  : Apply this cmd command to each message content
                        before the copy.
@@ -1104,7 +1108,7 @@ my(
         $uidnext_default,
         $fixcolonbug,
         $create_folder_old,
-        $skipcrossduplicates, $debugcrossduplicates,
+        $skipcrossduplicates, $debugcrossduplicates, $skipallmailduplicates,
         $disarmreadreceipts,
         $mixfolders,
         $fetch_hash_set,
@@ -2487,7 +2491,9 @@ FOLDER: foreach my $h1_fold ( @{ $sync->{h1_folders_wanted} } )
 
                 if ( ( not exists  $h2_hash{ $m_id }  )
                         and ( not ( exists $sync->{ h2_folders_of_md5 }->{ $m_id } )
-                              or not $skipcrossduplicates ) )
+                              or ( not $skipcrossduplicates 
+                                   and ( not $skipallmailduplicates 
+                                         or $h1_fold ne "[Gmail]/All Mail" ) ) ) )
                 {
                         # copy
                         my $h2_msg = copy_message( $sync, $h1_msg, $h1_fold, $h2_fold, $h1_fir_ref, $permanentflags2, $cache_dir ) ;
@@ -16802,6 +16808,7 @@ sub get_options_cmd
         'maxsleep=f'             => \$mysync->{maxsleep},
         'skipcrossduplicates!'   => \$skipcrossduplicates,
         'debugcrossduplicates!'  => \$debugcrossduplicates,
+        'skipallmailduplicates!' => \$skipallmailduplicates,
         'log!'                   => \$mysync->{log},
         'tail!'                  => \$mysync->{tail},
         'logfile=s'        => \$mysync->{logfile},

--- a/imapsync
+++ b/imapsync
@@ -15486,11 +15486,11 @@ sub gmail12
 	$mysync->{maxbytesafter} ||= 1_000_000_000 ;
 	$mysync->{automap}   = ( defined $mysync->{automap} )  ? $mysync->{automap} : 1 ;
 	$mysync->{maxsleep}  = ( defined $mysync->{maxsleep} ) ? $mysync->{maxsleep} : $MAX_SLEEP ; ;
-	$skipcrossduplicates = ( defined $skipcrossduplicates ) ? $skipcrossduplicates : 0 ;
         $mysync->{ synclabels  }   = ( defined $mysync->{ synclabels } )  ? $mysync->{ synclabels } : 1 ;
         $mysync->{ resynclabels }   = ( defined $mysync->{ resynclabels } )  ? $mysync->{ resynclabels } : 1 ;
-	push @exclude, '\[Gmail\]$' ;
-        push @folderlast, '[Gmail]/All Mail' ;
+        # If we resync labels then we only need to do the All Mail folder since all messages
+        # will be in it and all will get their correct labels in the destination.
+        push @{ $mysync->{ folder } }, '[Gmail]/All Mail' ;
 	return ;
 }
 
@@ -15505,7 +15505,11 @@ sub gmail1
 	$mysync->{maxbytesafter} ||= 2_500_000_000 ;
 	$mysync->{automap}   = ( defined $mysync->{automap} ) ? $mysync->{automap} : 1 ;
 	$mysync->{maxsleep}  = ( defined $mysync->{maxsleep} ) ? $mysync->{maxsleep} : $MAX_SLEEP ; ;
-	$skipcrossduplicates = ( defined $skipcrossduplicates ) ? $skipcrossduplicates : 1 ;
+	if ( not defined $skipcrossduplicates 
+	     and not defined $skipallmailduplicates ) {
+	        $skipcrossduplicates = 0;
+	        $skipallmailduplicates = 1;
+	}
 
 	push @useheader, 'X-Gmail-Received', 'Message-Id' ;
 	push @{ $mysync->{ regextrans2 } }, 's,\[Gmail\].,,' ;
@@ -15523,7 +15527,6 @@ sub gmail2
 	$mysync->{maxbytesafter} ||= 1_000_000_000 ; # In fact it is documented as half: 500_000_000
 
 	$mysync->{automap} = ( defined $mysync->{automap} ) ? $mysync->{automap} : 1 ;
-	#$skipcrossduplicates = ( defined $skipcrossduplicates ) ? $skipcrossduplicates : 1 ;
 	$mysync->{ expunge1 }  = ( defined $mysync->{ expunge1 } )  ? $mysync->{ expunge1 }  : 1 ;
 	$mysync->{addheader} = ( defined $mysync->{addheader} ) ? $mysync->{addheader} : 1 ;
 	$mysync->{maxsleep}  = ( defined $mysync->{maxsleep} )  ? $mysync->{maxsleep} : $MAX_SLEEP ; ;


### PR DESCRIPTION
This change adds a new option: "skipallmailduplicates" which works much like skipcrossduplicates but applies only to the GMail "All Mail" folder.  This is useful for copying gmail to other if most messages have very few GMail labels and you want them to go into a folder for each label, but don't want messages that are labeled to also go into the All Mail folder.

It also changes the gmail to gmail default options to process only the All Mail folder.  It already implied sync and resync labels so this is enough to do a full gmail to gmail sync.  Everything is in All Mail and this way all messages will be copied and will have all the correct labels.