### PR TITLE
Add procps to Dockerfile

### DIFF
--- a/INSTALL.d/Dockerfile
+++ b/INSTALL.d/Dockerfile
@@ -56,6 +56,7 @@ RUN set -xe                 && \
   libtest-warn-perl            \
   make                         \
   cpanminus                    \
+  procps                       \
   wget
 
 RUN wget -N https://imapsync.lamiral.info/imapsync && \


### PR DESCRIPTION
Fixes:
`Can't exec "ps": No such file or directory at /usr/bin/imapsync line 14902.`