### PR TITLE
Build Docker image in GH action workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,3 +19,5 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Build image
+        run: docker buildx build --platform linux/amd64,linux/arm64 -t imapsync:$(/usr/bin/git log -1 --format='%h')  . --no-cache -f INSTALL.d/Dockerfile


### PR DESCRIPTION
The current GH action flow doesn't actually build an image, just sets up the environment for it.

This builds an image for arm64 and amd64. Currently breaks; fixed by #300 