### PR TITLE
Use correct link to raw file in INSTALL.Debian.txt

### DIFF
--- a/INSTALL.d/INSTALL.Debian.txt
+++ b/INSTALL.d/INSTALL.Debian.txt
@@ -110,7 +110,7 @@ You don't have to be root to test and use imapsync.
 
 Take imapsync either on github:
 
-  wget -N https://github.com/imapsync/imapsync/blob/master/imapsync
+  wget -N https://github.com/imapsync/imapsync/raw/master/imapsync
 
 or be on the cutting edge with the upstream site:
 


### PR DESCRIPTION
Download the file itself instead of the HTML page showing the file