### PR TITLE
Fix locale for FreeBSD loadavg()

### DIFF
--- a/imapsync
+++ b/imapsync
@@ -16080,7 +16080,7 @@ sub loadavg_freebsd
 
 	if ( ! defined $file ) {
 		eval {
-			$loadavg = `/sbin/sysctl vm.loadavg` ;
+			$loadavg = `LC_ALL=C /sbin/sysctl vm.loadavg` ;
 			#myprint( "LOADAVG FREEBSD: $loadavg\n" ) ;
 		} ;
 		if ( $EVAL_ERROR ) { myprint( "[$EVAL_ERROR]\n" ) ; return ; }


### PR DESCRIPTION
For FreeBSD `sysctl` does not respect `LANG` environ. It uses `LC_NUMERIC`. To avoid any other bugs, I suggest `LC_ALL=C`.