### PR TITLE
change references to the gone linux-france.org domain

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -124,7 +124,7 @@ Suggested default --useheader 'Message-ID' --useheader 'Received'
 
 Ameir Abdeldayem
 Gave a patch to sync messages lacking Message-ID
-http://www.linux-france.org/prj/imapsync_list/msg01151.html
+https://web.archive.org/web/20160913193638/http://www.linux-france.org/prj/imapsync_list/msg01151.html
 
 Yousaf Shah
 Contributed by giving the book

--- a/README
+++ b/README
@@ -880,7 +880,7 @@ SIMILAR SOFTWARE
      imapmigrate: http://sourceforge.net/projects/cyrus-utils/
      larch: https://github.com/rgrove/larch (derived from wonko_imapsync, good at Gmail)
      wonko_imapsync: http://wonko.com/article/554 (superseded by larch)
-     pop2imap: http://www.linux-france.org/prj/pop2imap/ (I wrote that too)
+     pop2imap: https://pop2imap.lamiral.info/ (I wrote that too)
      exchange-away: http://exchange-away.sourceforge.net/
      SyncBackPro: http://www.2brightsparks.com/syncback/sbpro.html
      ImapSyncClient: https://github.com/ridaamirini/ImapSyncClient

--- a/S/external.shtml
+++ b/S/external.shtml
@@ -57,7 +57,7 @@
 <li> imapmigrate:        <a href="http://sourceforge.net/projects/cyrus-utils/">http://sourceforge.net/projects/cyrus-utils/</a></li>
 <li> larch:              <a href="https://github.com/rgrove/larch">https://github.com/rgrove/larch</a> (derived from wonko_imapsync, good at Gmail)</li>
 <li> wonko_imapsync:     <a href="http://web.archive.org/web/20130807173030/http://wonko.com/post/ruby_script_to_sync_email_from_any_imap_server_to_gmail">http://wonko.com/article/554</a> (superseded by larch)</li>
-<li> pop2imap:           <a href="http://www.linux-france.org/prj/pop2imap/">http://www.linux-france.org/prj/pop2imap/</a> (I wrote that too)</li>
+<li> pop2imap:           <a href="https://pop2imap.lamiral.info/">https://pop2imap.lamiral.info/</a> (I wrote that too)</li>
 <li> exchange-away:      <a href="http://exchange-away.sourceforge.net/">http://exchange-away.sourceforge.net/</a></li>
 <li> SyncBackPro:        <a href="http://www.2brightsparks.com/syncback/sbpro.html">http://www.2brightsparks.com/syncback/sbpro.html</a></li>
 

--- a/S/mailing_list.shtml
+++ b/S/mailing_list.shtml
@@ -61,8 +61,8 @@ http://www.w3schools.com/html/html5_browsers.asp
 
 <p>
     The <b>list archives</b> are available at
-    <a  href="http://www.linux-france.org/prj/imapsync_list/">
-    http://linux-france.org/prj/imapsync_list/</a><br />
+    <a  href="https://web.archive.org/web/20211024051744/http://linux-france.org/prj/imapsync_list/">
+    https://web.archive.org/web/20211024051744/http://linux-france.org/prj/imapsync_list/</a><br />
     So consider that the list is public, anyone can see your post.<br />
     <i>Use a pseudonym or do not post to
     this list if you want to stay private</i>.<br />

--- a/S/no_download.shtml
+++ b/S/no_download.shtml
@@ -41,7 +41,7 @@ to pay for free speech software.
 not gratis from the homepage. It is the best decision I've done
 about imapsync to continue to maintain it.
 See detailed motivations in this 
-<a href="http://www.linux-france.org/prj/imapsync_list/msg00459.html">call for business solution</a>.
+<a href="https://web.archive.org/web/20210309005209/http://www.linux-france.org/prj/imapsync_list/msg00459.html">call for business solution</a>.
 </p>
 
 <p>"Download and donate if happy" doesn't work well.<br/>

--- a/doc/TUTORIAL_Unix.html
+++ b/doc/TUTORIAL_Unix.html
@@ -317,7 +317,7 @@ Here comes imapsync.
 <P>
 In case the source mailbox is only accessible by the POP protocol,
 you can use the tool <CODE>pop2imap</CODE> to sync them.
-<CODE>pop2imap</CODE> is located at <A HREF="http://www.linux-france.org/prj/pop2imap/">http://www.linux-france.org/prj/pop2imap/</A>
+<CODE>pop2imap</CODE> is located at <A HREF="https://pop2imap.lamiral.info/">https://pop2imap.lamiral.info/</A>
 </P>
 
 <A NAME="toc10"></A>

--- a/doc/TUTORIAL_Unix.t2t
+++ b/doc/TUTORIAL_Unix.t2t
@@ -209,7 +209,7 @@ Here comes imapsync.
 
 In case the source mailbox is only accessible by the POP protocol,
 you can use the tool ``pop2imap`` to sync them.
-``pop2imap`` is located at http://www.linux-france.org/prj/pop2imap/
+``pop2imap`` is located at https://pop2imap.lamiral.info/
 
 
 + Imapsync presentation +

--- a/examples/sync_loop_windows.bat
+++ b/examples/sync_loop_windows.bat
@@ -59,7 +59,7 @@
 
 @REM For Parallel executions, there is also a PowerShell script written by 
 @REM CARTER Alex explained and located on the imapsync archive list:
-@REM http://www.linux-france.org/prj/imapsync_list/msg02137.html
+@REM https://web.archive.org/web/20190917193548/http://www.linux-france.org/prj/imapsync_list/msg02137.html
 
 @REM ==== The real stuff is below ====
 

--- a/imapsync
+++ b/imapsync
@@ -939,7 +939,7 @@ List verified on Friday July 1, 2021.
  imapmigrate: http://sourceforge.net/projects/cyrus-utils/
  larch: https://github.com/rgrove/larch (derived from wonko_imapsync, good at Gmail)
  wonko_imapsync: http://wonko.com/article/554 (superseded by larch)
- pop2imap: http://www.linux-france.org/prj/pop2imap/ (I wrote that too)
+ pop2imap: https://pop2imap.lamiral.info/ (I wrote that too)
  exchange-away: http://exchange-away.sourceforge.net/
  SyncBackPro: http://www.2brightsparks.com/syncback/sbpro.html
  ImapSyncClient: https://github.com/ridaamirini/ImapSyncClient

--- a/index.shtml
+++ b/index.shtml
@@ -176,7 +176,7 @@ so one of the most open license of the universe.
 
 It is the best decision I've made about imapsync in order to continue to maintain it.
 See detailed explanation and motivation here when 
-<a href="http://www.linux-france.org/prj/imapsync_list/msg00459.html">I looked for a business model</a>.
+<a href="https://web.archive.org/web/20210309005209/http://www.linux-france.org/prj/imapsync_list/msg00459.html">I looked for a business model</a>.
 
 "Download and donate if happy" doesn't work well.
 "Pay for download and I pay back if unhappy" works well, a 100 times better.


### PR DESCRIPTION
In noticed the www.linux-france.org domain is gone.

I edited a few files that had references to pop2imap over there (http://www.linux-france.org/prj/pop2imap/) to where I guess pop2imap is now (https://pop2imap.lamiral.info/).

I also found a few references to the English language mailing list archive in http://www.linux-france.org/prj/imapsync_list/ to the archived pages in https://archive.org